### PR TITLE
Fix compilation error

### DIFF
--- a/AimBot.csproj
+++ b/AimBot.csproj
@@ -80,6 +80,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>


### PR DESCRIPTION
PoeHUD was complaining that there is no reference to System.Linq.
Adding a reference to System.Core fixes this problem, and Aimbot compiles and works correctly